### PR TITLE
Update sample dependencies

### DIFF
--- a/plugin-markdown-better/package.json
+++ b/plugin-markdown-better/package.json
@@ -16,27 +16,14 @@
     "displayName": "Better Markdown editor (plugin)"
   },
   "scripts": {
-    "lint": "eslint *.js settings || true"
+    "lint": "eslint ."
   },
   "devDependencies": {
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^8.0.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "babel-register": "^6.18.0",
-    "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0",
-    "webpack": "1.11.0"
-  },
-  "dependencies": {
-    "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-logger": "^0.0.2",
-    "lodash": "^4.17.4",
-    "react-router-dom": "^4.0.0"
+    "@folio/eslint-config-stripes": "^3.2.1",
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes-connect": "^3.1.0",
     "@folio/stripes-core": "^2.9.0",
     "react": "*"
   }

--- a/plugin-markdown-editor/package.json
+++ b/plugin-markdown-editor/package.json
@@ -16,27 +16,14 @@
     "displayName": "Mike's Markdown editor (plugin)"
   },
   "scripts": {
-    "lint": "eslint *.js settings || true"
+    "lint": "eslint ."
   },
   "devDependencies": {
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^8.0.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "babel-register": "^6.18.0",
-    "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0",
-    "webpack": "1.11.0"
-  },
-  "dependencies": {
-    "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-logger": "^0.0.2",
-    "lodash": "^4.17.4",
-    "react-router-dom": "^4.0.0"
+    "@folio/eslint-config-stripes": "^3.2.1",
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes-connect": "^3.1.0",
     "@folio/stripes-core": "^2.9.0",
     "react": "*"
   }


### PR DESCRIPTION
Removes unused dependencies and uses latest version of `eslint-config-stripes`.

Should make for easier maintenance of these examples.